### PR TITLE
typo-Update lib.rs

### DIFF
--- a/modules/claims/src/lib.rs
+++ b/modules/claims/src/lib.rs
@@ -409,7 +409,7 @@ pub mod pallet {
     ) -> Result<BalanceOf<T>, DispatchError> {
       let bridge_account = Self::elastic_bridge_accounts(network);
 
-      // mint must be orginated from bridge account
+      // mint must be originated from bridge account
       ensure!(
         Some(&from) == bridge_account.as_ref(),
         Error::<T>::NoPermission


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
- `modules/claims/src/lib.rs:412`: "orginated" corrected to "originated".

## Purpose
- Improved code accuracy and professionalism by fixing the typo.
